### PR TITLE
allow no service to ever have been registered

### DIFF
--- a/lib/rspec/sidecar/services.rb
+++ b/lib/rspec/sidecar/services.rb
@@ -63,6 +63,8 @@ module RSpec::Sidecar::Services
         puts "waiting for service '#{name}:#{type}' to unregister (tries left: #{retries})"
       rescue SidecarNotAvailable => _
         return true
+      rescue ZK::Exceptions::NoNode => _
+        return true
       end
     end
   end

--- a/spec/rspec_sidecar_spec.rb
+++ b/spec/rspec_sidecar_spec.rb
@@ -78,6 +78,15 @@ describe RSpec::Sidecar do
 
   it "the service_is_unregistered method returns true for no registerd service at path" do
     expect(zookeeper).to receive(:children).with("/banno/services/test-not-registered:http") do
+      raise ZK::Exceptions::NoNode
+    end
+
+    result = service_is_unregistered("test-not-registered", "http")
+    expect(result).to be true
+  end
+
+  it "the service_is_unregistered method returns true for unregisterd service at path" do
+    expect(zookeeper).to receive(:children).with("/banno/services/test-not-registered:http") do
       []
     end
 


### PR DESCRIPTION
if a service has never been registered, we should say it is
'unregistered'.
