### PR TITLE
update rest-client dependency version

### DIFF
--- a/lib/rspec/sidecar/version.rb
+++ b/lib/rspec/sidecar/version.rb
@@ -1,5 +1,5 @@
 module RSpec
   module Sidecar
-    VERSION = "0.0.1"
+    VERSION = "0.0.2"
   end
 end

--- a/rspec-sidecar.gemspec
+++ b/rspec-sidecar.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "rspec", "~> 3.1.0"
   spec.add_runtime_dependency "zk", "~> 1.9.4"
-  spec.add_runtime_dependency "rest-client", "~> 1.7.2"
+  spec.add_runtime_dependency "rest-client", "~> 1.8.0"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Updates the `rest-client` dependency version so that it doesn't break for those with Ruby 2.4+

Closes https://github.com/Banno/big/issues/723